### PR TITLE
OneSignal: remove charset from content-type

### DIFF
--- a/one-signal/one-signal.js
+++ b/one-signal/one-signal.js
@@ -24,7 +24,7 @@ module.exports = function (event) {
 
 const sendNotification = function(data) {
   const headers = {
-    'Content-Type': 'application/json charset=utf-8',
+    'Content-Type': 'application/json',
     'Authorization': APP_KEY
   }
 


### PR DESCRIPTION
OneSignal's API returns this error with charset specified:
```json
{
  "errors": [
    "app_id not found. You may be missing a Content-Type: application/json header."
  ]
}
```