### PR TITLE
rename `facebookUserId` to `facebookToken`

### DIFF
--- a/authentication/facebook-authentication/facebook-authentication.graphql
+++ b/authentication/facebook-authentication/facebook-authentication.graphql
@@ -3,5 +3,5 @@ type User {
 
   # Must be unique
   # Make it required if Facebook is the only authorization method in your app
-  facebookUserId: String @isUnique
+  facebookToken: String @isUnique
 }


### PR DESCRIPTION
not sure if this is correct, but everywhere else in this tutorial I only see references to a `facebookToken`. unless the `facebookToken` and the `facebookUserId` are actually two different things I think the field should be renamed to `facebookToken`